### PR TITLE
Add dynamic OAuth provider selection and auth config endpoint

### DIFF
--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -44,6 +44,9 @@ auth:
     client_secret: "pllm-web-secret"
     redirect_url: "http://localhost:3000/auth/callback"
     scopes: ["openid", "profile", "email", "groups"]
+    # Enabled OAuth providers (must match connector IDs in your dex config)
+    # Remove providers you don't want to show in the login page
+    enabled_providers: ["github", "microsoft"]  # Removed "google"
 
 # Router configuration with adaptive routing for high-load scenarios
 router:

--- a/config.yaml
+++ b/config.yaml
@@ -110,6 +110,9 @@ auth:
     client_secret: "pllm-web-secret" # OAuth2 client secret
     redirect_url: "http://localhost:8080/auth/callback" # OAuth2 redirect URL
     scopes: ["openid", "profile", "email", "groups"] # OAuth2 scopes
+    # Enabled OAuth providers (must match connector IDs in your dex config)
+    # Comment out or remove providers you don't want to show in the login page
+    enabled_providers: ["github", "microsoft"]  # Removed "google"
 
 # ===========================
 # Logging Configuration

--- a/deploy/dex/config.docker.yaml
+++ b/deploy/dex/config.docker.yaml
@@ -15,7 +15,7 @@ storage:
 
 web:
   http: 0.0.0.0:5556
-  allowedOrigins: ['*']
+  allowedOrigins: ["*"]
 
 grpc:
   addr: 0.0.0.0:5557
@@ -83,13 +83,13 @@ connectors:
         - read:org
 
   # Google OAuth
-  - type: google
-    id: google
-    name: Google
-    config:
-      clientID: $GOOGLE_CLIENT_ID
-      clientSecret: $GOOGLE_CLIENT_SECRET
-      redirectURI: http://localhost:5556/dex/callback
+  # - type: google
+  #   id: google
+  #   name: Google
+  #   config:
+  #     clientID: $GOOGLE_CLIENT_ID
+  #     clientSecret: $GOOGLE_CLIENT_SECRET
+  #     redirectURI: http://localhost:5556/dex/callback
 
   # Microsoft OAuth
   - type: microsoft

--- a/deploy/helm/pllm/files/config.yaml
+++ b/deploy/helm/pllm/files/config.yaml
@@ -69,6 +69,12 @@ auth:
     client_secret: ${DEX_CLIENT_SECRET}
     redirect_url: "http://localhost:8080/auth/callback"
     scopes: ["openid", "profile", "email", "groups"]
+    {{- if .Values.pllm.config.auth.dex.enabledProviders }}
+    enabled_providers:
+      {{- range .Values.pllm.config.auth.dex.enabledProviders }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
 
 # Logging Configuration
 logging:

--- a/deploy/helm/pllm/values.yaml
+++ b/deploy/helm/pllm/values.yaml
@@ -31,7 +31,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1000
@@ -115,44 +115,45 @@ pllm:
   config:
     # Database configuration
     database:
-      host: ""  # Will be auto-configured if postgresql is enabled
+      host: "" # Will be auto-configured if postgresql is enabled
       port: 5432
       name: pllm
       user: pllm
-      password: ""  # Use secret
+      password: "" # Use secret
       sslMode: require
       maxOpenConns: 10
       maxIdleConns: 5
 
-    # Redis configuration  
+    # Redis configuration
     redis:
-      host: ""  # Will be auto-configured if redis is enabled
+      host: "" # Will be auto-configured if redis is enabled
       port: 6379
-      password: ""  # Use secret
+      password: "" # Use secret
       db: 0
 
     # Authentication configuration
     auth:
-      jwtSecret: ""  # Use secret
-      masterKey: ""  # Use secret
+      jwtSecret: "" # Use secret
+      masterKey: "" # Use secret
       dex:
-        issuer: ""  # Backend internal URL - Will be auto-configured if dex is enabled
-        publicIssuer: ""  # Frontend public URL - Defaults to issuer if not set
+        issuer: "" # Backend internal URL - Will be auto-configured if dex is enabled
+        publicIssuer: "" # Frontend public URL - Defaults to issuer if not set
         clientId: pllm
-        clientSecret: ""  # Use secret
+        clientSecret: "" # Use secret
+        enabledProviders: [] # OAuth providers to enable in login page, e.g., ["github", "google"]
 
     # Provider API keys
     providers:
       openai:
-        apiKey: ""  # Use secret
+        apiKey: "" # Use secret
       anthropic:
-        apiKey: ""  # Use secret
+        apiKey: "" # Use secret
       azure:
-        apiKey: ""  # Use secret
+        apiKey: "" # Use secret
         endpoint: ""
       bedrock:
-        accessKeyId: ""  # Use secret
-        secretAccessKey: ""  # Use secret
+        accessKeyId: "" # Use secret
+        secretAccessKey: "" # Use secret
         region: us-east-1
 
     # Rate limiting
@@ -172,9 +173,9 @@ pllm:
   # Secrets configuration
   secrets:
     # Database connection URL (for external databases)
-    databaseUrl: ""  # e.g., "postgres://user:pass@host:5432/db?sslmode=require"
-    # Redis connection URL (for external Redis)  
-    redisUrl: ""     # e.g., "redis://:password@host:6379/0"
+    databaseUrl: "" # e.g., "postgres://user:pass@host:5432/db?sslmode=require"
+    # Redis connection URL (for external Redis)
+    redisUrl: "" # e.g., "redis://:password@host:6379/0"
     # JWT secret for token signing
     jwtSecret: ""
     # Master key for admin access
@@ -217,19 +218,19 @@ dex:
   enabled: true
   # This will be templated to use the correct internal service name
   config:
-    issuer: http://pllm-dex.pllm.svc.cluster.local:5556/dex  # Will be overridden by template
+    issuer: http://pllm-dex.pllm.svc.cluster.local:5556/dex # Will be overridden by template
     storage:
       type: kubernetes
       config:
         inCluster: true
     web:
       http: 0.0.0.0:5556
-      allowedOrigins: ['*']
+      allowedOrigins: ["*"]
     staticClients:
       - id: pllm
         redirectURIs:
-          - 'http://localhost:3000/auth/callback'
-        name: 'PLLM'
+          - "http://localhost:3000/auth/callback"
+        name: "PLLM"
         secret: pllm-client-secret
     connectors:
       - type: mockCallback

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,10 +191,12 @@ services:
       - GROK_API_KEY_1=${GROK_API_KEY:-}
       - MISTRAL_API_KEY_1=${MISTRAL_API_KEY:-}
       # Dex Authentication - Use public URL for both (backend handles internal routing)
+      - DEX_ENABLED=${DEX_ENABLED:-true}
       - DEX_ISSUER=http://localhost:5556/dex
       - DEX_PUBLIC_ISSUER=http://localhost:5556/dex
       - DEX_CLIENT_ID=pllm-web
       - DEX_CLIENT_SECRET=pllm-web-secret
+      - DEX_ENABLED_PROVIDERS=${DEX_ENABLED_PROVIDERS:-github,microsoft}
       # Master Key for bootstrap admin access
       - PLLM_MASTER_KEY=${PLLM_MASTER_KEY:-sk-master-dev-key-change-in-production}
       - AUTH_MASTER_KEY=${PLLM_MASTER_KEY:-sk-master-dev-key-change-in-production}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,14 +76,15 @@ type AuthConfig struct {
 }
 
 type DexConfig struct {
-	Enabled       bool              `mapstructure:"enabled"`
-	Issuer        string            `mapstructure:"issuer"`        // Backend connection URL
-	PublicIssuer  string            `mapstructure:"public_issuer"` // Frontend OAuth URL
-	ClientID      string            `mapstructure:"client_id"`
-	ClientSecret  string            `mapstructure:"client_secret"`
-	RedirectURL   string            `mapstructure:"redirect_url"`
-	Scopes        []string          `mapstructure:"scopes"`
-	GroupMappings map[string]string `mapstructure:"group_mappings"`
+	Enabled          bool              `mapstructure:"enabled"`
+	Issuer           string            `mapstructure:"issuer"`        // Backend connection URL
+	PublicIssuer     string            `mapstructure:"public_issuer"` // Frontend OAuth URL
+	ClientID         string            `mapstructure:"client_id"`
+	ClientSecret     string            `mapstructure:"client_secret"`
+	RedirectURL      string            `mapstructure:"redirect_url"`
+	Scopes           []string          `mapstructure:"scopes"`
+	GroupMappings    map[string]string `mapstructure:"group_mappings"`
+	EnabledProviders []string          `mapstructure:"enabled_providers"` // Which OAuth providers are enabled
 }
 
 type CacheConfig struct {
@@ -269,6 +270,7 @@ func setDefaults() {
 	viper.SetDefault("auth.require_auth", false)
 	viper.SetDefault("auth.dex.enabled", false)
 	viper.SetDefault("auth.dex.scopes", []string{"openid", "profile", "email", "groups"})
+	viper.SetDefault("auth.dex.enabled_providers", []string{})
 }
 
 func bindEnvVars() {
@@ -311,6 +313,7 @@ func bindEnvVars() {
 	_ = viper.BindEnv("auth.dex.client_id", "DEX_CLIENT_ID")
 	_ = viper.BindEnv("auth.dex.client_secret", "DEX_CLIENT_SECRET")
 	_ = viper.BindEnv("auth.dex.redirect_url", "DEX_REDIRECT_URL")
+	_ = viper.BindEnv("auth.dex.enabled_providers", "DEX_ENABLED_PROVIDERS")
 
 	// Cache
 	_ = viper.BindEnv("cache.ttl", "CACHE_TTL")

--- a/internal/router/admin.go
+++ b/internal/router/admin.go
@@ -64,6 +64,7 @@ func NewAdminSubRouter(cfg *AdminRouterConfig) http.Handler {
 	r.Post("/auth/login", authHandler.Login)
 	r.Post("/auth/master-key", authHandler.MasterKeyLogin) // Master key authentication
 	r.Get("/auth/validate", authHandler.Validate)
+	r.Get("/auth/config", systemHandler.GetAuthConfig) // Get available auth options
 	r.Post("/auth/token", oauthHandler.TokenExchange)
 	r.Get("/auth/userinfo", oauthHandler.UserInfo)
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amerfu/pllm/internal/config"
 	"github.com/amerfu/pllm/internal/docs"
 	"github.com/amerfu/pllm/internal/handlers"
+	"github.com/amerfu/pllm/internal/handlers/admin"
 	"github.com/amerfu/pllm/internal/middleware"
 	"github.com/amerfu/pllm/internal/services"
 	"github.com/amerfu/pllm/internal/services/budget"
@@ -190,11 +191,15 @@ func NewRouter(cfg *config.Config, logger *zap.Logger, modelManager *models.Mode
 	}
 	authHandler := handlers.NewAuthHandler(logger, authService, masterKeyService, db)
 
+	// Initialize system handler for auth config
+	systemHandler := admin.NewSystemHandler(logger)
+
 	// Public routes
 	r.Group(func(r chi.Router) {
 		r.Post("/v1/register", authHandler.Register)
 		r.Post("/v1/login", authHandler.Login)
 		r.Post("/v1/refresh", authHandler.RefreshToken)
+		r.Get("/api/auth/config", systemHandler.GetAuthConfig) // Public auth config
 	})
 
 	// Protected routes

--- a/web/src/config/auth.ts
+++ b/web/src/config/auth.ts
@@ -36,7 +36,7 @@ const oidcConfig: UserManagerSettings = {
   
   // Redirect URIs
   redirect_uri: `${window.location.origin}/ui/callback`,
-  post_logout_redirect_uri: `${window.location.origin}/ui`,
+  post_logout_redirect_uri: `${window.location.origin}/ui/login`,
   silent_redirect_uri: `${window.location.origin}/ui/silent-renew`,
   
   // Response type for authorization code flow

--- a/web/src/contexts/OIDCAuthContext.tsx
+++ b/web/src/contexts/OIDCAuthContext.tsx
@@ -262,7 +262,7 @@ export function OIDCAuthProvider({ children }: { children: ReactNode }) {
       }
       
       // Get the return URL from state or default to dashboard
-      const returnUrl = parsedState?.returnUrl || "/ui/dashboard";
+      const returnUrl = parsedState?.returnUrl || "/dashboard";
       console.log("Navigating to:", returnUrl);
       
       // Use replace to avoid back button issues
@@ -283,7 +283,7 @@ export function OIDCAuthProvider({ children }: { children: ReactNode }) {
         variant: "destructive",
       });
       setIsLoading(false);
-      navigate("/ui/login", { replace: true });
+      navigate("/login", { replace: true });
     }
   };
 
@@ -378,7 +378,7 @@ export function OIDCAuthProvider({ children }: { children: ReactNode }) {
         description: "Logged in with master key",
       });
 
-      navigate("/ui/dashboard");
+      navigate("/dashboard");
     } catch (error) {
       console.error("Master key login error:", error);
       toast({
@@ -400,7 +400,7 @@ export function OIDCAuthProvider({ children }: { children: ReactNode }) {
       sessionStorage.clear();
       
       // Navigate to login page
-      navigate("/ui/login");
+      navigate("/login");
       
       toast({
         title: "Success",
@@ -412,7 +412,7 @@ export function OIDCAuthProvider({ children }: { children: ReactNode }) {
       setUser(null);
       localStorage.removeItem("authToken");
       sessionStorage.clear();
-      navigate("/ui/login");
+      navigate("/login");
     }
   };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -124,6 +124,9 @@ const api = {
 
 export default api;
 
+// Auth API
+export const getAuthConfig = (): Promise<any> => axiosInstance.get("/api/auth/config");
+
 // Legacy exports for backward compatibility
 export const healthCheck = () => axiosInstance.get("/health");
 export const getDatabaseStatus = () =>


### PR DESCRIPTION
- Introduce `enabled_providers` to Dex config for selective OAuth display - Add `/api/auth/config` endpoint to expose available auth methods - Update login page to fetch and render auth options dynamically
- Remove Google from default enabled providers - Adjust OIDC and navigation routes for consistency - Update Helm and Docker configs for provider selection